### PR TITLE
Manage very big files

### DIFF
--- a/src/main/java/com/ask/home/videostream/constants/ApplicationConstants.java
+++ b/src/main/java/com/ask/home/videostream/constants/ApplicationConstants.java
@@ -11,6 +11,8 @@ public class ApplicationConstants {
     public static final String BYTES = "bytes";
     public static final int BYTE_RANGE = 1024;
 
+    public static final int RESPONSE_MAX_RANGE = 1048576; // 1MB (max size of a chunck sent to client)
+    
     private ApplicationConstants() {
     }
 }


### PR DESCRIPTION
I was getting a Java heap error when trying to get a very big large video (about 800Mb) with  the HTML5 video tag.

I put a limit to the chunk sent to client if rangeEnd is not specified in the request header (like "Range: bytes 0-").

And most important: in the loop that read the file it's not good to read every times the whole file when you want to return just a chunk, so I fixed it.

